### PR TITLE
Enable custom Lucene build with luceneutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ In order to run a test, you need to configure your test environment:
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | RUN_ID           | (String) Unique run identifier                                                                                                                                                                                                                                                                                                        |
 | SHARE_DATA_PATH  | (String) File path where everything will be mounted. In this path, there should be a folder, lucene-data, which will be where lucene-data is stored. This allows for a different device to be used. In this path, you should put the necessary parameters and the necessary datasets because itll be accessible by the osb container. |
-| LUCENEUTIL_REPO  | Repo containing custom OSB workloads. If you want to add custom extensions, etc, fork the workloads, add them to main branch, and push. By default, it will be the default workloads                                                                                                                                                  |
+| LUCENEUTIL_REPO  | Git repository containing your luceneutil fork to build and run benchmarks |
+| LUCENE_VERSION   | Version string used when building lucene |
 | TEST_REPO        | Link to lucene repo. Plugin will be built from source from here.                                                                                                                                                                                                                                                                      |
 | TEST_BRANCH      | Lucene branch name. Plugin will be built from source from here                                                                                                                                                                                                                                                                        |
 | TEST_JVM         | Amount of JVM to be used for test container (i.e. 32g)                                                                                                                                                                                                                                                                                |
@@ -55,6 +56,7 @@ SHARE_DATA_PATH=
 LUCENEUTIL_REPO=
 TEST_REPO=
 TEST_BRANCH=
+LUCENE_VERSION=
 TEST_JVM=
 TEST_CPU_COUNT=
 TEST_MEM_SIZE=

--- a/compose-test.yaml
+++ b/compose-test.yaml
@@ -1,17 +1,19 @@
 services:
   test:
     image: custom-luceneutil
-    build:
-      context: test-image
-      dockerfile: Dockerfile.testbuild
-      args:
-        TEST_REPO: ${TEST_REPO}
-        TEST_BRANCH: ${TEST_BRANCH}
-        OPENSEARCH_VERSION: ${LUCENE_VERSION}
+      build:
+        context: test-image
+        dockerfile: Dockerfile.testbuild
+        args:
+          TEST_REPO: ${TEST_REPO}
+          TEST_BRANCH: ${TEST_BRANCH}
+          LUCENEUTIL_REPO: ${LUCENEUTIL_REPO}
+          OPENSEARCH_VERSION: ${LUCENE_VERSION}
     container_name: test
-    environment:
-      - "OPENSEARCH_JAVA_OPTS=-Xms${TEST_JVM} -Xmx${TEST_JVM} -XX:StartFlightRecording=delay=5s,dumponexit=true,filename=/share-data/profiles/${RUN_ID}.jfr"
-      - "RUN_ID=${RUN_ID}"
+      environment:
+        - "OPENSEARCH_JAVA_OPTS=-Xms${TEST_JVM} -Xmx${TEST_JVM} -XX:StartFlightRecording=delay=5s,dumponexit=true,filename=/share-data/profiles/${RUN_ID}.jfr"
+        - "RUN_ID=${RUN_ID}"
+        - "LUCENE_UTIL_ARGS=${LUCENE_UTIL_ARGS}"
     ulimits:
       memlock:
         soft: -1

--- a/test-image/Dockerfile.testbuild
+++ b/test-image/Dockerfile.testbuild
@@ -1,20 +1,22 @@
-# Build the plugin
-ARG LUCENE_VERSION
+# Stage to build lucene and luceneutil
 FROM eclipse-temurin:23 as build
-COPY ./build-lucene.sh /
 
-ARG LUCENE_VERSION
 ARG TEST_REPO
 ARG TEST_BRANCH
-RUN echo ${LUCENE_VERSION}
-RUN bash /build-luceneutil.sh ${TEST_REPO} ${TEST_BRANCH} ${LUCENE_VERSION}
+ARG LUCENEUTIL_REPO
+
+COPY ./build-lucene.sh /
+COPY ./build-luceneutil.sh /
+
+RUN bash /build-lucene.sh ${TEST_REPO} ${TEST_BRANCH}
+RUN bash /build-luceneutil.sh ${LUCENEUTIL_REPO}
 
 # Build the actual image
 FROM eclipse-temurin:23
-ARG LUCENE_VERSION
 USER root
-RUN yum install unzip procps -y
-USER luceneutil
+RUN yum install -y unzip procps ant git && rm -rf /var/cache/yum
+COPY --from=build /lucene /lucene
+COPY --from=build /luceneutil /luceneutil
 COPY custom-entrypoint.sh /custom-entrypoint.sh
 COPY utils/process-stats-collector.sh /process-stats-collector.sh
 

--- a/test-image/build-lucene.sh
+++ b/test-image/build-lucene.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
 
+# Build a custom version of Lucene from a given repository and branch.
 set -xe
 
 export JAVA_HOME=/opt/java/openjdk-23
-echo ${JAVA_HOME}
+
 REPO_ENDPOINT=$1
 REPO_BRANCH=$2
-LUCENE_VERSION=$3
-git clone -b $REPO_BRANCH $REPO_ENDPOINT TODO
-cd k-NN
-ARCH=$(arch)
-if [ "$ARCH" = "x86_64" ]; then
-    ARCHITECTURE=x64
-else
-    ARCHITECTURE=arm64
-fi
 
-bash scripts/build.sh -v ${LUCENE_VERSION} -s true -a ${ARCHITECTURE}
+git clone --depth 1 -b "$REPO_BRANCH" "$REPO_ENDPOINT" /lucene
+cd /lucene
+./gradlew publishToMavenLocal -x test
+cd /

--- a/test-image/build-luceneutil.sh
+++ b/test-image/build-luceneutil.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Build luceneutil using the lucene sources that were built in build-lucene.sh
+# Arguments:
+#   $1 - Git repository for luceneutil
+
+set -xe
+
+LUCENEUTIL_REPO=$1
+
+git clone --depth 1 "$LUCENEUTIL_REPO" /luceneutil
+cd /luceneutil
+ant jar
+cd /

--- a/test-image/custom-entrypoint.sh
+++ b/test-image/custom-entrypoint.sh
@@ -8,18 +8,12 @@ SHARED_PATH=/share-data
 PROFILE_PATH=${SHARED_PATH}/profiles
 mkdir -p -m 777 ${PROFILE_PATH}
 
-# TODO: Somehow run custom lucene util.,
+cd /luceneutil
+ant run -Dargs="${LUCENE_UTIL_ARGS}" &
+ENTRY_PID=$!
 
-ENTRY_PID=0 #TODO
-echo "Entry: ${ENTRY_PID}"
 sleep 5
-# TODO: Fix this
-LUCENEUTIL_PID=`ps aux | grep "lucene" | tr -s ' ' | cut -d ' ' -f2`
-echo "LUCENEUTIL: ${LUCENEUTIL_PID}"
-# Collect lower level process stats
 
-# TODO: bash /process-stats-collector.sh ${LUCENEUTIL_PID} ${RUN_ID} &
-# Graceful shutdown poller lets other containers stop OS if necessary (so that profiles can be dumped)
-# TODO: bash /graceful-shutdown-poller.sh ${LUCENEUTIL_PID} &
-# Foreground original process
+bash /process-stats-collector.sh ${ENTRY_PID} ${RUN_ID} &
+
 fg %1


### PR DESCRIPTION
## Summary
- build a custom Lucene checkout and luceneutil when creating the Docker image
- run luceneutil in the container entrypoint
- allow passing luceneutil repo, lucene version, and benchmark args via compose
- document new environment options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b5a644308328b030b3dda3657a70