### PR TITLE
Generate runnable script from web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ In remote mode, it will just run the OSB workload against an external endpoint.
 
 ### Example usage
 
-Before starting, you need to create an environment variable file, test.env, that contains all of the configs. 
-See [Parameters](#parameters) for more details. 
+Before starting, you need to create a small script, `run.sh`, that contains all of the configs.
+See [Parameters](#parameters) for more details.
 
 To run end to end, 
 ```
-docker compose --env-file test.env -f compose-test.yaml up
+./run.sh
 
 # Stop the framework
-docker compose --env-file test.env -f compose-test.yaml down
+docker compose -f compose-test.yaml down
 ```
 
 ### Parameters
@@ -49,8 +49,9 @@ In order to run a test, you need to configure your test environment:
 | TEST_MEM_SIZE    | Amount of total memory test container will be limited at. (i.e. 4G)                                                                                                                                                                                                                                                                   |
 | LUCENE_UTIL_ARGS | OSB procedure to be run                                                                                                                                                                                                                                                                                                               |
 
-Here is an example `test.env` for local:
+Here is an example `run.sh` for local:
 ```
+#!/bin/bash
 RUN_ID=
 SHARE_DATA_PATH=
 LUCENEUTIL_REPO=
@@ -61,6 +62,8 @@ TEST_JVM=
 TEST_CPU_COUNT=
 TEST_MEM_SIZE=
 LUCENE_UTIL_ARGS=
+
+docker compose -f compose-test.yaml up
 ```
 
 
@@ -68,8 +71,9 @@ LUCENE_UTIL_ARGS=
 ### Web UI
 
 A minimal static page is provided in the `web` directory to help configure tests.
-Open `web/index.html` in your browser, fill in the values and click **Download Env File**. This will create a `test.env` file that can be used to run the test locally:
+Open `web/index.html` in your browser, fill in the values and click **Download Run Script**. This will create a `run.sh` file that can be used to run the test locally:
 
 ```bash
-docker compose --env-file test.env -f compose-test.yaml up
+chmod +x run.sh
+./run.sh
 ```

--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
 </head>
 <body class="container">
   <h3>Lucene Test Runner</h3>
-  <form id="testForm" onsubmit="return generateEnv();">
+  <form id="testForm" onsubmit="return generateScript();">
     <div class="input-field">
       <input id="RUN_ID" name="RUN_ID" type="text" required>
       <label for="RUN_ID">Run ID</label>
@@ -51,38 +51,41 @@
       </select>
       <label>Run Type</label>
     </div>
-    <button class="btn waves-effect waves-light" type="submit">Download Env File</button>
+    <button class="btn waves-effect waves-light" type="submit">Download Run Script</button>
   </form>
 
   <div id="instructions" class="section">
-    <p>After downloading <code>test.env</code>, run:</p>
-    <pre>docker compose --env-file test.env -f compose-test.yaml up</pre>
+    <p>After downloading <code>run.sh</code>, make it executable and run:</p>
+    <pre>chmod +x run.sh
+./run.sh</pre>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      var elems = document.querySelectorAll('select');
-      M.FormSelect.init(elems);
-    });
-
-    function generateEnv() {
-      var formData = new FormData(document.getElementById('testForm'));
-      var lines = [];
-      formData.forEach(function(value, key) {
-        if (value) {
-          lines.push(key + '=' + value);
-        }
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        var elems = document.querySelectorAll('select');
+        M.FormSelect.init(elems);
       });
-      var blob = new Blob([lines.join('\n') + '\n'], {type: 'text/plain'});
-      var url = URL.createObjectURL(blob);
-      var a = document.createElement('a');
-      a.href = url;
-      a.download = 'test.env';
-      a.click();
-      URL.revokeObjectURL(url);
-      return false;
-    }
-  </script>
+
+      function generateScript() {
+        var formData = new FormData(document.getElementById('testForm'));
+        var lines = ['#!/bin/bash'];
+        formData.forEach(function(value, key) {
+          if (value) {
+            lines.push(key + '="' + value.replace(/"/g, '\\"') + '"');
+          }
+        });
+        lines.push('');
+        lines.push('docker compose -f compose-test.yaml up');
+        var blob = new Blob([lines.join('\n') + '\n'], {type: 'text/plain'});
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'run.sh';
+        a.click();
+        URL.revokeObjectURL(url);
+        return false;
+      }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- download run.sh instead of env file from the web page
- update instructions to use run.sh

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862c6b7e2d88328b441e784ca61163f