### PR TITLE
Add new benchmarking options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ In order to run a test, you need to configure your test environment:
 | TEST_CPU_COUNT   | Number of CPUs test container will get. (i.e. 2)                                                                                                                                                                                                                                                                                      |
 | TEST_MEM_SIZE    | Amount of total memory test container will be limited at. (i.e. 4G)                                                                                                                                                                                                                                                                   |
 | LUCENE_UTIL_ARGS | OSB procedure to be run                                                                                                                                                                                                                                                                                                               |
+| INDEX_THREAD_COUNT | Number of threads used when indexing |
+| ENABLE_FORCEMERGE | Enable force merge before running the benchmark (true/false) |
+| MAX_CONCURRENT_CLIENTS | Maximum concurrent clients for QPS benchmark |
 
 Here is an example `run.sh` for local:
 ```
@@ -61,6 +64,9 @@ LUCENE_VERSION=
 TEST_JVM=
 TEST_CPU_COUNT=
 TEST_MEM_SIZE=
+INDEX_THREAD_COUNT=
+ENABLE_FORCEMERGE=
+MAX_CONCURRENT_CLIENTS=
 LUCENE_UTIL_ARGS=
 
 docker compose -f compose-test.yaml up

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,21 @@
       <label for="TEST_MEM_SIZE">Memory Size (e.g. 4G)</label>
     </div>
     <div class="input-field">
+      <input id="INDEX_THREAD_COUNT" name="INDEX_THREAD_COUNT" type="number">
+      <label for="INDEX_THREAD_COUNT">Index Thread Count</label>
+    </div>
+    <div class="switch">
+      <label>
+        ForceMerge
+        <input id="ENABLE_FORCEMERGE" name="ENABLE_FORCEMERGE" type="checkbox">
+        <span class="lever"></span>
+      </label>
+    </div>
+    <div class="input-field">
+      <input id="MAX_CONCURRENT_CLIENTS" name="MAX_CONCURRENT_CLIENTS" type="number">
+      <label for="MAX_CONCURRENT_CLIENTS">Max Concurrent Clients</label>
+    </div>
+    <div class="input-field">
       <input id="LUCENE_UTIL_ARGS" name="LUCENE_UTIL_ARGS" type="text">
       <label for="LUCENE_UTIL_ARGS">Lucene Util Args</label>
     </div>
@@ -68,13 +83,16 @@
       });
 
       function generateScript() {
-        var formData = new FormData(document.getElementById('testForm'));
+        var form = document.getElementById('testForm');
+        var formData = new FormData(form);
         var lines = ['#!/bin/bash'];
         formData.forEach(function(value, key) {
+          if (key === 'ENABLE_FORCEMERGE') return;
           if (value) {
             lines.push(key + '="' + value.replace(/"/g, '\\"') + '"');
           }
         });
+        lines.push('ENABLE_FORCEMERGE=' + (document.getElementById('ENABLE_FORCEMERGE').checked ? 'true' : 'false'));
         lines.push('');
         lines.push('docker compose -f compose-test.yaml up');
         var blob = new Blob([lines.join('\n') + '\n'], {type: 'text/plain'});


### PR DESCRIPTION
## Summary
- add fields for index thread count, forcemerge toggle, and max concurrent clients in the web UI
- update script generation to output ENABLE_FORCEMERGE variable
- document the new options in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863511026088328a4841e75b8b2ccde